### PR TITLE
fix: expose rebindPrinter() in public API and add null-safety guard

### DIFF
--- a/android/src/main/kotlin/br/com/brasizza/sunmi_printer_plus/SunmiPrinterPlusPlugin.kt
+++ b/android/src/main/kotlin/br/com/brasizza/sunmi_printer_plus/SunmiPrinterPlusPlugin.kt
@@ -38,7 +38,20 @@ class SunmiPrinterPlusPlugin : FlutterPlugin, MethodCallHandler {
         channel.setMethodCallHandler(this)
     }
 
+    private val isPrinterReady: Boolean
+        get() = ::sunmiPrinter.isInitialized && ::printerCommand.isInitialized
+
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        // Allow rebindPrinter and getPlatformVersion without printer being ready
+        if (call.method != "rebindPrinter" && call.method != "getPlatformVersion" && !isPrinterReady) {
+            result.error(
+                "PRINTER_NOT_INITIALIZED",
+                "Printer is not initialized yet. Call rebindPrinter() first.",
+                null
+            )
+            return
+        }
+
         when (call.method) {
             "rebindPrinter" -> {
                 sunmiInit.initPrinter { selectPrinter ->

--- a/lib/src/sunmi/sunmi_printer.dart
+++ b/lib/src/sunmi/sunmi_printer.dart
@@ -129,12 +129,25 @@ class SunmiPrinter {
 
   /// bindingPrinter the printer.
   ///
-  /// **Deprecated**: This method will be removed in a future version.
+  /// **Deprecated**: Use [rebindPrinter] instead.
   ///
   /// Returns `null`.
-  @Deprecated('This method will be removed in a future version. ')
+  @Deprecated('Use rebindPrinter() instead.')
   static Future<bool?> bindingPrinter() async {
     return null;
+  }
+
+  /// Re-initializes the printer binding.
+  ///
+  /// This triggers the native AIDL service discovery and initializes
+  /// all printer subsystems (printer, command, LCD, drawer).
+  ///
+  /// Call this if the automatic initialization in `onAttachedToEngine`
+  /// hasn't completed yet, or if you need to re-establish the connection.
+  ///
+  /// Returns `true` if the printer was found and initialized, `false` otherwise.
+  static Future<bool> rebindPrinter() async {
+    return await SunmiPrinterPlusPlatform.instance.rebindPrinter();
   }
 
   /// Prints custom text using a [SunmiText] object.


### PR DESCRIPTION
## Problem

Fixes #105

In v4.x, `bindingPrinter()` and `initPrinter()` are deprecated no-ops that return `null`. The actual printer initialization happens asynchronously in `onAttachedToEngine` via a callback. 

If any print method (e.g. `printEscPos`, `printText`, `printImage`) is called before that callback has resolved, the `lateinit` properties (`printerCommand`, `sunmiPrinter`, etc.) are not yet assigned, causing a crash:

```
PlatformException(error, lateinit property printerCommand has not been initialized, ...)
```

The `rebindPrinter()` method exists on the native side and in `MethodChannelSunmiPrinterPlus`, but is not exposed in the public `SunmiPrinter` class — so there's no way for users to explicitly ensure the printer is ready.

## Fix

**Dart side** (`sunmi_printer.dart`):
- Expose `SunmiPrinter.rebindPrinter()` that delegates to `SunmiPrinterPlusPlatform.instance.rebindPrinter()`
- Update `bindingPrinter()` deprecation message to point to `rebindPrinter()`

**Kotlin side** (`SunmiPrinterPlusPlugin.kt`):
- Add `isPrinterReady` computed property using `::printerCommand.isInitialized`
- Add a guard at the top of `onMethodCall`: if the printer isn't ready and the method isn't `rebindPrinter`/`getPlatformVersion`, return a clear `PRINTER_NOT_INITIALIZED` error instead of crashing

## Usage

```dart
// Ensure the printer is ready before printing
final isReady = await SunmiPrinter.rebindPrinter();
if (isReady) {
  await SunmiPrinter.printEscPos(data);
}
```